### PR TITLE
change webpack externals config from "Matter" to "matter-js"

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ const banner = `${name} ${pkg.version} by ${author} ${date}
 ${pkg.homepage}
 License ${pkg.license}`;
 
-var postBuildTasks = { 
+var postBuildTasks = {
   apply: function(compiler) {
     compiler.plugin('after-emit', function(compiler, callback) {
       var matterToolsPath = path.dirname(require.resolve('matter-tools')) + '/build/matter-tools.demo.js';
@@ -27,7 +27,7 @@ var postBuildTasks = {
           /(['"])(.*)(['"][;,\s]*\/\/\s*PLUGIN_REPO_URL)/g
         ],
         with: [
-          "$1" + name + "$3", 
+          "$1" + name + "$3",
           "$1" + pkg.version + "$3",
           "$1" + pkg.repository.url.replace('.git', '') + "$3"
         ]
@@ -62,7 +62,7 @@ module.exports = {
     libraryTarget: 'umd'
   },
   externals: {
-    'matter-js': 'Matter'
+    'matter-js': 'matter-js'
   },
   module: {
     loaders: [{


### PR DESCRIPTION
I was running into issues when trying to import `matter-collision-events`, and I noticed it was reproducible on `matter-attractors`.

The test case and issue can be found [here](https://github.com/dxu/matter-test/tree/master/webpack-externals). Note the error for matter-attractors.

When importing it and then trying to build it, it would complain that `Matter` was not found. I fixed this in `matter-collision-events` by specifying the externals value as `matter-js` (the name of the Matter package).

My editor automatically took out some trailing whitespace in the file as well, hence the other three lines, but let me know if you want to leave that in.